### PR TITLE
Add a profile for quasselclient

### DIFF
--- a/apparmor.d/usr.bin.quasselclient
+++ b/apparmor.d/usr.bin.quasselclient
@@ -1,0 +1,20 @@
+#include <tunables/global>
+
+/usr/bin/quasselclient {
+  #include <abstractions/base>
+  #include <abstractions/dbus-session>
+  #include <abstractions/kde>
+  #include <abstractions/nameservice>
+
+  /etc/xdg/** r,
+  @{HOME}/.ICEauthority r,
+  @{HOME}/.Xauthority r,
+  @{HOME}/.config/Trolltech.conf r,
+  @{HOME}/.config/quassel-irc.org/** rw,
+  @{HOME}/.kde/** rw,
+  @{HOME}/.local/share/** r,
+  /usr/bin/quasselclient mr,
+  /usr/share/** r,
+  /var/tmp/** rwlk,
+
+}


### PR DESCRIPTION
This profile is tested against QuasselClient version `0.12.2 (dist-9c5e6c6)`. It was originally published at https://gogs.dsprenkels.com/dsprenkels/apparmor-profiles.

I guess I should add this profile to the [readme file](https://github.com/cryptofuture/apparmor-profiles/blob/master/README.md), but I am not sure in which category I should put it.