### PR TITLE
Allow writes to Dovecot's mail_temp_dir

### DIFF
--- a/apparmor.d/abstractions/dovecot-common
+++ b/apparmor.d/abstractions/dovecot-common
@@ -18,4 +18,4 @@
 
   /{var/,}run/dovecot/config rw,
   # Directory set in mail_temp_dir
-  /tmp/dovecot.* w,
+  /tmp/dovecot.* rw,

--- a/apparmor.d/abstractions/dovecot-common
+++ b/apparmor.d/abstractions/dovecot-common
@@ -17,3 +17,5 @@
   signal receive peer=/usr/sbin/dovecot,
 
   /{var/,}run/dovecot/config rw,
+  # Directory set in mail_temp_dir
+  /tmp/dovecot.* w,


### PR DESCRIPTION
I had the following error in the logs:

```
Mar 08 21:46:12 xxx2 audit[24050]: AVC apparmor="DENIED" operation="mknod" profile="/usr/lib/dovecot/imap" name="/tmp/dovecot.imap.xxx2.24050.55f26bbcf923d5e0" pid=24050 comm="imap" requested_mask="c" denied_mask="c" fsuid=1020310 ouid=1020310
Mar 08 21:46:12 xxx2 kernel: audit: type=1400 audit(1552092372.439:104071): apparmor="DENIED" operation="mknod" profile="/usr/lib/dovecot/imap" name="/tmp/dovecot.imap.xxx2.24050.55f26bbcf923d5e0" pid=24050 comm="imap" requested_mask="c" denied_mask="c" fsuid=1020310 ouid=1020310
Mar 08 21:46:12 xxx2 dovecot[3516]: imap(andre@xxx.com.br): Error: Temp file creation to /tmp/dovecot.imap. failed: Permission denied
```

Several programs need access to mail_temp_dir:

https://www.dovecot.org/list/dovecot/2013-June/090861.html

All files created there start with the string "dovecot.":

```
void mail_user_set_get_temp_prefix(string_t *dest,
				   const struct mail_user_settings *set)
{
	str_append(dest, set->mail_temp_dir);
	str_append(dest, "/dovecot.");
	str_append(dest, master_service_get_name(master_service));
	str_append_c(dest, '.');
}
```